### PR TITLE
仮名であったblankがいつまでも消えなかったため削除

### DIFF
--- a/src/app/components/members/members.service.ts
+++ b/src/app/components/members/members.service.ts
@@ -176,7 +176,7 @@ export class InputMembersService  {
         if (this.isEnable(column)) {
           // グループNo の入力がない入力行には、仮のグループid をつける
           if (column.g_no === null) {
-            column.g_id = 'blank'; //'row' + column.m_no; //仮のグループid
+            column.g_id = ''; //'row' + column.m_no; //仮のグループid
           }
 
           const def = this.default_member(column.m_no);

--- a/src/app/providers/dsd-data.service.ts
+++ b/src/app/providers/dsd-data.service.ts
@@ -1094,7 +1094,7 @@ export class DsdDataService {
       strfix10 = this.readString(buff, 10);
       member.g_no = this.helper.toNumber(strfix10.trim());
       if (member.g_no === null) {
-        member.g_id = 'blank';
+        member.g_id = '';
       } else {
         member.g_id = member.g_no.toString();
       }

--- a/src/app/providers/dsd-data.service.ts
+++ b/src/app/providers/dsd-data.service.ts
@@ -1094,7 +1094,7 @@ export class DsdDataService {
       strfix10 = this.readString(buff, 10);
       member.g_no = this.helper.toNumber(strfix10.trim());
       if (member.g_no === null) {
-        member.g_id = '';
+        member.g_id = 'blank';
       } else {
         member.g_id = member.g_no.toString();
       }


### PR DESCRIPTION
#157 
memberのグループNo.が未入力の場合に、g_idを"blank"としていたため、空行に"blank"と入力されてしまっていた。
![image](https://user-images.githubusercontent.com/109077766/226924052-dedacfc3-ebf3-4268-988c-7f428369c14f.png)

マニュアルモードの場合、データの入っている行はすべて読み込んでしまうため、
本来は空行であるはずの"blank"の入った行も読み込まれてしまう。

印刷の際に右上の[　]はグループ番号（g_no）からグループ名（g_name）を呼び出して挿入するが、
グループ番号はグループ番号全体をソートして、グループ番号の若い順に選択するようになっている。
![image](https://user-images.githubusercontent.com/109077766/226932296-7f9b5d7e-f523-4ad8-bfe8-bab47114e923.png)
![image](https://user-images.githubusercontent.com/109077766/226931421-16ddf0bf-f0f7-4f3e-8409-6965859c230a.png)

しかし、"blank"行のグループ番号はすべて空であり、ソートすると一番前に来る。
その結果、右上の[　]には"blank"行の空のグループ名が最初に挿入され、今回のissueが引き起ったと考えられる。

ファイルを保存するときにmemberのグループNo.が未入力の場合は、g_idを未入力のままとすることで対応した。