### PR TITLE
鉄筋の表題において、「bars.」となっている項目を「折曲げ鉄筋」「処理」に修正

### DIFF
--- a/src/app/components/bars/bars.component.ts
+++ b/src/app/components/bars/bars.component.ts
@@ -219,7 +219,7 @@ export class BarsComponent implements OnInit, OnDestroy, AfterViewInit {
         title: 'tanγ+tanβ', dataType: 'float', dataIndx: 'tan', sortable: false, width: 85, nodrag: true,
       },
       {
-        title: this.translate.instant("bars."),
+        title: this.translate.instant("bars.rebar_fo"),
         align: 'center', colModel: [
           {
             title: this.translate.instant("bars.dia"),
@@ -241,7 +241,7 @@ export class BarsComponent implements OnInit, OnDestroy, AfterViewInit {
         nodrag: true,
       },
       {
-        title: this.translate.instant("bars."),
+        title: this.translate.instant("bars.process"),
         align: 'center', dataType: 'bool', dataIndx: 'enable', type: 'checkbox', sortable: false, width: 40, nodrag: true,
       },
     );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/109077766/231317962-272ab70b-3b39-45a1-9dbb-6040531d41ff.png)

鉄筋配置の表題が「bars.」となっていたので、それぞれ「折曲げ鉄筋」「処理」に修正