### PR TITLE
WebDan v2.5.2において断面力データが未入力の際に断面力メニューを開くと無限ループする問題の修正 task1673

### DIFF
--- a/src/app/components/section-forces/section-forces.component.ts
+++ b/src/app/components/section-forces/section-forces.component.ts
@@ -239,6 +239,10 @@ export class SectionForcesComponent implements OnInit, AfterViewInit, OnDestroy 
 
     // データを登録する
     this.ROWS_COUNT = this.force.getDataCount();
+    if (this.ROWS_COUNT === 0) {
+      // ROWS_COUNTが0だとbeforeTableView()の中で無限ループが発生してしまう
+      this.ROWS_COUNT = this.rowsCount();
+    }
     this.loadData(this.ROWS_COUNT);
 
     this.columnHeaders1 = this.force.getColumnHeaders1();
@@ -519,6 +523,12 @@ export class SectionForcesComponent implements OnInit, AfterViewInit, OnDestroy 
     // containerHeight /= 2;
 
     return containerHeight;
+  }
+
+  // 表高さに合わせた行数を計算する
+  private rowsCount(): number {
+    const containerHeight = this.tableHeight();
+    return Math.round(containerHeight / 30);
   }
 
   public activePageChenge(id: number): void {


### PR DESCRIPTION
https://www.notion.so/WebDan-v2-5-2-272b586afd11809f923dd7fb85f35172

修正前の`rowsCount()`関数を復活させ、`ROWS_COUNT`が0の際は`rowsCount()`の戻り値を使用するようにしました。